### PR TITLE
Mirror of zeromq libzmq#3483

### DIFF
--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -77,10 +77,7 @@ static int sleep_ms (unsigned int ms_)
 {
     if (ms_ == 0)
         return 0;
-#if defined ZMQ_HAVE_WINDOWS
-    Sleep (ms_ > 0 ? ms_ : INFINITE);
-    return 0;
-#elif defined ZMQ_HAVE_ANDROID
+#if defined ZMQ_HAVE_ANDROID
     usleep (ms_ * 1000);
     return 0;
 #elif defined ZMQ_HAVE_VXWORKS


### PR DESCRIPTION
Mirror of zeromq libzmq#3483
Solution: remove it since sleep_ms isn't used on Windows
