### PR TITLE
Mirror of zeromq libzmq#3478

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1331,7 +1331,7 @@ if(BUILD_SHARED)
       target_link_libraries(benchmark_radix_tree libzmq-static)
       target_include_directories(benchmark_radix_tree
         PUBLIC
-        "${CMAKE_SOURCE_DIR}/src")
+        "${CMAKE_CURRENT_LIST_DIR}/src")
     endif()
 
   endif()

--- a/RELICENSE/omegastick.md
+++ b/RELICENSE/omegastick.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Isaac Poulton
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "Omegastick", with
+commit author "Omegastick", are copyright of Isaac Poulton.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Isaac Poulton
+2019/04/14


### PR DESCRIPTION
Mirror of zeromq libzmq#3478
When LIbzmq is used with `add_subdirectory` in CMake, it can't find the includes for the Radix Tree benchmarks because they are found using `CMAKE_SOURCE_DIR`, which points to the source of the whole project, not the libzmq source.

This changes that to `CMAKE_CURRENT_LIST_DIR` which works as expected.
