### PR TITLE
Mirror of zeromq libzmq#3476

### DIFF
--- a/RELICENSE/tommd.md
+++ b/RELICENSE/tommd.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Thomas M. DuBuisson
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "tommd", with
+commit author "Thomas M. DuBuisson", are copyright of Thomas M. DuBuisson.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Thomas M. DuBuisson
+2019/04/11

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -82,21 +82,20 @@ int zmq::req_t::xsend (msg_t *msg_)
             _request_id++;
 
             //  Copy request id before sending (see issue #1695 for details).
-            uint32_t *request_id_copy =
-              static_cast<uint32_t *> (malloc (sizeof (uint32_t)));
-            zmq_assert (request_id_copy);
+            uint32_t request_id_copy;
 
-            *request_id_copy = _request_id;
+            request_id_copy = _request_id;
 
             msg_t id;
             int rc =
-              id.init_data (request_id_copy, sizeof (uint32_t), free_id, NULL);
+              id.init_data (&request_id_copy, sizeof (uint32_t), free_id, NULL);
             errno_assert (rc == 0);
             id.set_flags (msg_t::more);
 
             rc = dealer_t::sendpipe (&id, &_reply_pipe);
-            if (rc != 0)
+            if (rc != 0) {
                 return -1;
+            }
         }
 
         msg_t bottom;


### PR DESCRIPTION
Mirror of zeromq libzmq#3476
Problem: xsend() can leak memory

Solution: free memory in case of error return from sendpipe().

