### PR TITLE
Mirror of zeromq libzmq#3462

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ test_socket_null
 test_xpub_verbose
 test_mock_pub_sub
 test_proxy_hwm
+test_sndtimeo_zero
 unittest_ip_resolver
 unittest_mtrie
 unittest_poller

--- a/Makefile.am
+++ b/Makefile.am
@@ -459,7 +459,8 @@ test_apps = \
 	tests/test_sodium \
 	tests/test_reconnect_ivl \
 	tests/test_mock_pub_sub \
-	tests/test_socket_null
+	tests/test_socket_null \
+	tests/test_sndtimeo_zero
 
 UNITY_CPPFLAGS = -I$(top_srcdir)/external/unity -DUNITY_USE_COMMAND_LINE_ARGS -DUNITY_EXCLUDE_FLOAT
 UNITY_LIBS = $(top_builddir)/external/unity/libunity.a
@@ -773,6 +774,10 @@ tests_test_reconnect_ivl_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 tests_test_mock_pub_sub_SOURCES = tests/test_mock_pub_sub.cpp
 tests_test_mock_pub_sub_LDADD = src/libzmq.la ${TESTUTIL_LIBS}
 tests_test_mock_pub_sub_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
+
+tests_test_sndtimeo_zero_SOURCES = tests/test_sndtimeo_zero.cpp
+tests_test_sndtimeo_zero_LDADD = src/libzmq.la ${TESTUTIL_LIBS}
+tests_test_sndtimeo_zero_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 
 if HAVE_CURVE
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1142,7 +1142,13 @@ int zmq::socket_base_t::send (msg_t *msg_, int flags_)
     //  In case of non-blocking send we'll simply propagate
     //  the error - including EAGAIN - up the stack.
     if ((flags_ & ZMQ_DONTWAIT) || options.sndtimeo == 0) {
-        return -1;
+        if (unlikely (process_commands (0, false) != 0)) {
+            return -1;
+        }
+
+        rc = xsend (msg_);
+
+        return rc;
     }
 
     //  Compute the time when the timeout should occur.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ set(tests
   test_socket_null
   test_reconnect_ivl
   test_mock_pub_sub
+  test_sndtimeo_zero
 )
 
 if(NOT WIN32)

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -110,15 +110,20 @@ int test_blocking (int send_hwm_, int msg_cnt_, const char *endpoint)
 {
     size_t len = SOCKET_STRING_LEN;
     char pub_endpoint[SOCKET_STRING_LEN];
+    int bufsize = 4096;
 
     // Set up bind socket
     void *pub_socket = test_context_socket (ZMQ_XPUB);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (pub_socket, ZMQ_SNDBUF, &bufsize, sizeof (int)));
     TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (pub_socket, endpoint));
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_getsockopt (pub_socket, ZMQ_LAST_ENDPOINT, pub_endpoint, &len));
 
     // Set up connect socket
     void *sub_socket = test_context_socket (ZMQ_SUB);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (pub_socket, ZMQ_RCVBUF, &bufsize, sizeof (int)));
     TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sub_socket, pub_endpoint));
 
     //set a hwm on publisher
@@ -143,9 +148,16 @@ int test_blocking (int send_hwm_, int msg_cnt_, const char *endpoint)
     int recv_count = 0;
     int blocked_count = 0;
     int is_termination = 0;
+
+    zmq_msg_t msg;
+    zmq_msg_init (&msg);
+
     while (send_count < msg_cnt_) {
-        const int rc = zmq_send (pub_socket, NULL, 0, ZMQ_DONTWAIT);
-        if (rc == 0) {
+        zmq_msg_close (&msg);
+        zmq_msg_init_size (&msg, 100);
+
+        const int rc = zmq_msg_send (&msg, pub_socket, ZMQ_DONTWAIT);
+        if (rc >= 0) {
             ++send_count;
         } else if (-1 == rc) {
             // if the PUB socket blocks due to HWM, errno should be EAGAIN:
@@ -154,6 +166,8 @@ int test_blocking (int send_hwm_, int msg_cnt_, const char *endpoint)
             recv_count += receive (sub_socket, &is_termination);
         }
     }
+
+    zmq_msg_close (&msg);
 
     // if send_hwm_ < msg_cnt_, we should block at least once:
     TEST_ASSERT (blocked_count > 0);

--- a/tests/test_sndtimeo_zero.cpp
+++ b/tests/test_sndtimeo_zero.cpp
@@ -1,0 +1,72 @@
+/*
+    Copyright (c) 2007-2017 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+#include "testutil_unity.hpp"
+
+#include <stdlib.h>
+
+SETUP_TEARDOWN_TESTCONTEXT
+
+void test_sndtimeo_zero (void)
+{
+    int timeo = 0;
+    int hwm = 5;
+
+    void *sb = test_context_socket (ZMQ_DEALER);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (sb, ZMQ_RCVHWM, &hwm, sizeof (int)));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb, "inproc://a"));
+
+    void *sc = test_context_socket (ZMQ_DEALER);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (sc, ZMQ_SNDHWM, &hwm, sizeof (int)));
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (sc, ZMQ_SNDTIMEO, &timeo, sizeof (int)));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sc, "inproc://a"));
+
+    const char bounce_content[] = "12345678ABCDEFGH12345678abcdefgh";
+
+    for (int i = 0; i < 10000; ++i) {
+        send_string_expect_success (sc, bounce_content, 0);
+        recv_string_expect_success (sb, bounce_content, 0);
+    }
+
+    test_context_socket_close (sc);
+    test_context_socket_close (sb);
+}
+
+int main (void)
+{
+    setup_test_environment ();
+
+    UNITY_BEGIN ();
+    RUN_TEST (test_sndtimeo_zero);
+    return UNITY_END ();
+}


### PR DESCRIPTION
Mirror of zeromq libzmq#3462
Because don't wait or timeout zero rarely process commands, the send operation might fail even if the pipe is not full.
Recv method is already protecting again such a behavior. The following example will fail, although it is clear that the pipe is not full:

```C
    void *ctx = zmq_ctx_new ();
    int timeo = 0;
    int hwm = 1;

    void *sb = zmq_socket (ctx, ZMQ_DEALER);
    zmq_setsockopt (sb, ZMQ_RCVHWM, &hwm, sizeof (int));
    zmq_bind (sb, "inproc://a");

    void *sc = zmq_socket (ctx, ZMQ_DEALER);
    zmq_setsockopt (sc, ZMQ_SNDHWM, &hwm, sizeof (int));
    zmq_setsockopt (sc, ZMQ_SNDTIMEO, &timeo, sizeof (int));
    zmq_connect (sc, "inproc://a");

    zmq_msg_t msg;
    zmq_msg_init (&msg);

    for (int i = 0; i < 10000; ++i) {
        int rc = zmq_msg_send (&msg, sc, 0);
        assert (rc >= 0);

        zmq_msg_recv (&msg, sb, 0);
    }

    zmq_msg_close (&msg);

    zmq_close (sb);
    zmq_close (sc);
    zmq_ctx_term (ctx);
```

Suggested solution: When send operation return EAGAIN with don't wait or zero timeout, process commands and try sending again.
