### PR TITLE
Mirror of zeromq libzmq#3460

### DIFF
--- a/unittests/unittest_poller.cpp
+++ b/unittests/unittest_poller.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <unity.h>
 
 #ifndef _WIN32
+#include <unistd.h>
 #define closesocket close
 #endif
 


### PR DESCRIPTION
Mirror of zeromq libzmq#3460
… gcc8

Solution: include unistd.h in unittest_poller.cpp

https://build.opensuse.org/build/network:messaging:zeromq:git-draft/Debian_Next/x86_64/libzmq/_log
