### PR TITLE
Mirror of zeromq libzmq#3456

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ test_ctx_options
 test_iov
 test_security
 test_security_curve
+test_security_no_zap_handler
 test_probe_router
 test_stream
 test_spec_dealer

--- a/tests/test_stream_exceeds_buffer.cpp
+++ b/tests/test_stream_exceeds_buffer.cpp
@@ -40,13 +40,6 @@ void tearDown ()
     teardown_test_context ();
 }
 
-#if defined(ZMQ_HAVE_WINDOWS)
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <stdexcept>
-#define close closesocket
-#endif
-
 void test_stream_exceeds_buffer ()
 {
     const int msgsize = 8193;
@@ -60,26 +53,9 @@ void test_stream_exceeds_buffer ()
     TEST_ASSERT_SUCCESS_RAW_ERRNO (setsockopt (server_sock, SOL_SOCKET,
                                                SO_REUSEADDR, (char *) &enable,
                                                sizeof (enable)));
-
-    struct sockaddr_in saddr;
-    memset (&saddr, 0, sizeof (saddr));
-    saddr.sin_family = AF_INET;
-    saddr.sin_addr.s_addr = INADDR_ANY;
-#if !defined(_WIN32_WINNT) || (_WIN32_WINNT >= 0x0600)
-    saddr.sin_port = 0;
-#else
-    saddr.sin_port = htons (12345);
-#endif
-
-    TEST_ASSERT_SUCCESS_RAW_ERRNO (
-      bind (server_sock, (struct sockaddr *) &saddr, sizeof (saddr)));
+    struct sockaddr_in saddr = bind_bsd_socket (server_sock);
     TEST_ASSERT_SUCCESS_RAW_ERRNO (listen (server_sock, 1));
 
-#if !defined(_WIN32_WINNT) || (_WIN32_WINNT >= 0x0600)
-    socklen_t saddr_len = sizeof (saddr);
-    TEST_ASSERT_SUCCESS_RAW_ERRNO (
-      getsockname (server_sock, (struct sockaddr *) &saddr, &saddr_len));
-#endif
     sprintf (my_endpoint, "tcp://127.0.0.1:%d", ntohs (saddr.sin_port));
 
     void *zsock = test_context_socket (ZMQ_STREAM);

--- a/tests/test_zmq_poll_fd.cpp
+++ b/tests/test_zmq_poll_fd.cpp
@@ -45,18 +45,6 @@ void tearDown ()
 
 void test_poll_fd ()
 {
-    struct addrinfo *addr, hint;
-    hint.ai_flags = AI_NUMERICHOST;
-    hint.ai_family = AF_INET;
-    hint.ai_socktype = SOCK_DGRAM;
-    hint.ai_protocol = IPPROTO_UDP;
-    hint.ai_addrlen = 0;
-    hint.ai_canonname = NULL;
-    hint.ai_addr = NULL;
-    hint.ai_next = NULL;
-
-    TEST_ASSERT_SUCCESS_ERRNO (getaddrinfo ("127.0.0.1", "6650", &hint, &addr));
-
     int recv_socket = socket (AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     TEST_ASSERT_NOT_EQUAL (-1, recv_socket);
 
@@ -64,8 +52,7 @@ void test_poll_fd ()
     TEST_ASSERT_SUCCESS_ERRNO (
       setsockopt (recv_socket, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof (int)));
 
-    TEST_ASSERT_SUCCESS_ERRNO (
-      bind (recv_socket, addr->ai_addr, addr->ai_addrlen));
+    struct sockaddr_in saddr = bind_bsd_socket (recv_socket);
 
     void *sb = test_context_socket (ZMQ_REP);
 
@@ -82,8 +69,8 @@ void test_poll_fd ()
     char buf[10];
     memset (buf, 1, 10);
 
-    TEST_ASSERT_SUCCESS_ERRNO (
-      sendto (send_socket, buf, 10, 0, addr->ai_addr, addr->ai_addrlen));
+    TEST_ASSERT_SUCCESS_ERRNO (sendto (
+      send_socket, buf, 10, 0, (struct sockaddr *) &saddr, sizeof (saddr)));
 
     TEST_ASSERT_EQUAL (1, zmq_poll (pollitems, 2, 1));
     TEST_ASSERT_BITS_LOW (ZMQ_POLLIN, pollitems[0].revents);
@@ -93,8 +80,6 @@ void test_poll_fd ()
 
     close (send_socket);
     close (recv_socket);
-
-    freeaddrinfo (addr);
 }
 
 int main ()


### PR DESCRIPTION
Mirror of zeromq libzmq#3456
Solution: move ephemeral port code to header and use it in both tests
