### PR TITLE
Mirror of zeromq libzmq#3453

### DIFF
--- a/RELICENSE/panlinux.md
+++ b/RELICENSE/panlinux.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Andreas Hasenack that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "panlinux", with
+commit author "Andreas Hasenack <andreas@canonical.com>", are
+copyright of Andreas Hasenack.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Andreas Hasenack
+2019/03/18
+

--- a/tests/test_filter_ipc.cpp
+++ b/tests/test_filter_ipc.cpp
@@ -122,8 +122,10 @@ void init_groups ()
     supgroup = group;
     notgroup = group + 1;
     for (int i = 0; i < ngroups; i++) {
-        if (supgroup == group && group != groups[i])
-            supgroup = groups[i];
+        if (supgroup == group && group != groups[i]) {
+            if (getgrgid (groups[i]))
+                supgroup = groups[i];
+        }
         if (notgroup <= groups[i])
             notgroup = groups[i] + 1;
     }

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -78,8 +78,10 @@
 #include <unistd.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <grp.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <net/if.h>


### PR DESCRIPTION
Mirror of zeromq libzmq#3453
Validate the group before using it

This makes the test a bit more robust in scenarios where, probably due  to a misconfiguration in the environment, a group present in the list of supplementary groups is not really a valid choice. This was seen in the Launchpad builders (where `getgrgid(supgroup)` returned `NULL`), and possibly elsewhere (see https://github.com/habitat-sh/core-plans/blob/master/zeromq/plan.sh#L22-L25)

This fixes issue #1462 
