### PR TITLE
Mirror of zeromq libzmq#3506

### DIFF
--- a/doc/zmq_socket_monitor_versioned.txt
+++ b/doc/zmq_socket_monitor_versioned.txt
@@ -11,6 +11,8 @@ zmq_socket_monitor_versioned - monitor socket events
 SYNOPSIS
 --------
 *int zmq_socket_monitor_versioned (void '*socket', char '*endpoint', uint64_t 'events', int 'event_version');*
+*int zmq_socket_monitor_versioned_typed (
+    void '*socket', char '*endpoint', uint64_t 'events', int 'event_version', int 'type');*
 
 *int zmq_socket_monitor_pipes_stats (void '*socket');*
 
@@ -55,6 +57,17 @@ connection uses a bound or connected local endpoint.
 
 Note that the format of the second and further frames, and also the number of
 frames, may be different for events added in the future.
+
+The _zmq_socket_monitor_versioned_typed()_ is a generalisation of
+_zmq_socket_monitor_versioned_ that supports more monitoring socket types.
+The 'type' argument is used to specify the type of the monitoring socket.
+Supported types are 'ZMQ_PAIR' (which is the equivalent of
+_zmq_socket_monitor_versioned_), 'ZMQ_PUB' and 'ZMQ_PUSH'. Note that consumers
+of the events will have to be compatible with the socket type, for instance a
+monitoring socket of type 'ZMQ_PUB' will require consumers of type 'ZMQ_SUB'.
+In the case that the monitoring socket type is of 'ZMQ_PUB', the multipart
+message topic is the event number, thus consumers should subscribe to the
+events they want to receive.
 
 The _zmq_socket_monitor_pipes_stats()_ method triggers an event of type
 ZMQ_EVENT_PIPES_STATS for each connected peer of the monitored socket.
@@ -213,6 +226,20 @@ sockets are required to use the inproc:// transport.
 
 *EINVAL*::
 The monitor 'endpoint' supplied does not exist.
+
+
+ERRORS - _zmq_socket_monitor_typed()_
+-------------------------------
+*ETERM*::
+The 0MQ 'context' associated with the specified 'socket' was terminated.
+
+*EPROTONOSUPPORT*::
+The transport protocol of the monitor 'endpoint' is not supported. Monitor
+sockets are required to use the inproc:// transport.
+
+*EINVAL*::
+The monitor 'endpoint' supplied does not exist or the specified socket 'type'
+is not supported.
 
 
 ERRORS - _zmq_socket_monitor_pipes_stats()_

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -735,6 +735,8 @@ ZMQ_EXPORT int zmq_socket_monitor_versioned (void *s_,
                                              const char *addr_,
                                              uint64_t events_,
                                              int event_version_);
+ZMQ_EXPORT int zmq_socket_monitor_versioned_typed (
+  void *s_, const char *addr_, uint64_t events_, int event_version_, int type_);
 ZMQ_EXPORT int zmq_socket_monitor_pipes_stats (void *s);
 
 #endif // ZMQ_BUILD_DRAFT_API

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -761,10 +761,10 @@ int zmq::options_t::setsockopt (int option_,
             break;
     }
 
-            // TODO mechanism should either be set explicitly, or determined when
-            // connecting. currently, it depends on the order of setsockopt calls
-            // if there is some inconsistency, which is confusing. in addition,
-            // the assumed or set mechanism should be queryable (as a socket option)
+        // TODO mechanism should either be set explicitly, or determined when
+        // connecting. currently, it depends on the order of setsockopt calls
+        // if there is some inconsistency, which is confusing. in addition,
+        // the assumed or set mechanism should be queryable (as a socket option)
 
 #if defined(ZMQ_ACT_MILITANT)
     //  There is no valid use case for passing an error back to the application

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1911,6 +1911,15 @@ void zmq::socket_base_t::stop_monitor (bool send_monitor_stopped_event_)
             monitor_event (ZMQ_EVENT_MONITOR_STOPPED, values, 1,
                            endpoint_uri_pair_t ());
         }
+        // Unbind the endpoint to free it up for subsequent reuse.
+        char endpoint[255];
+        size_t size = 255;
+        int rc =
+          zmq_getsockopt (_monitor_socket, ZMQ_LAST_ENDPOINT, endpoint, &size);
+        if (rc == 0 && endpoint) {
+            zmq_unbind (_monitor_socket, endpoint);
+        }
+
         zmq_close (_monitor_socket);
         _monitor_socket = NULL;
         _monitor_events = 0;

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1916,7 +1916,7 @@ void zmq::socket_base_t::stop_monitor (bool send_monitor_stopped_event_)
         size_t size = 255;
         int rc =
           zmq_getsockopt (_monitor_socket, ZMQ_LAST_ENDPOINT, endpoint, &size);
-        if (rc == 0 && endpoint) {
+        if (rc == 0 && endpoint[0] != '\0') {
             zmq_unbind (_monitor_socket, endpoint);
         }
 

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -119,7 +119,10 @@ class socket_base_t : public own_t,
     void lock ();
     void unlock ();
 
-    int monitor (const char *endpoint_, uint64_t events_, int event_version_);
+    int monitor (const char *endpoint_,
+                 uint64_t events_,
+                 int event_version_,
+                 int type_);
 
     void event_connected (const endpoint_uri_pair_t &endpoint_uri_pair_,
                           zmq::fd_t fd_);

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -255,7 +255,7 @@ int zmq::socks_connecter_t::connect_to_proxy ()
         }
     }
 
-        //  Connect to the remote peer.
+    //  Connect to the remote peer.
 #if defined ZMQ_HAVE_VXWORKS
     rc = ::connect (_s, (sockaddr *) tcp_addr->addr (), tcp_addr->addrlen ());
 #else

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -219,7 +219,7 @@ int zmq::tcp_connecter_t::open ()
             return -1;
     }
 
-        //  Connect to the remote peer.
+    //  Connect to the remote peer.
 #if defined ZMQ_HAVE_VXWORKS
     rc = ::connect (_s, (sockaddr *) tcp_addr->addr (), tcp_addr->addrlen ());
 #else
@@ -230,8 +230,8 @@ int zmq::tcp_connecter_t::open ()
         return 0;
     }
 
-        //  Translate error codes indicating asynchronous connect has been
-        //  launched to a uniform EINPROGRESS.
+    //  Translate error codes indicating asynchronous connect has been
+    //  launched to a uniform EINPROGRESS.
 #ifdef ZMQ_HAVE_WINDOWS
     const int last_error = WSAGetLastError ();
     if (last_error == WSAEINPROGRESS || last_error == WSAEWOULDBLOCK)

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -222,8 +222,8 @@ void zmq::udp_engine_t::plug (io_thread_t *io_thread_, session_base_t *session_)
         bool multicast = udp_addr->is_mcast ();
 
         if (multicast) {
-        //  Multicast addresses should be allowed to bind to more than
-        //  one port as all ports should receive the message
+            //  Multicast addresses should be allowed to bind to more than
+            //  one port as all ports should receive the message
 #ifdef SO_REUSEPORT
             rc = setsockopt (_fd, SOL_SOCKET, SO_REUSEPORT,
                              reinterpret_cast<char *> (&on), sizeof (on));

--- a/src/ypipe.hpp
+++ b/src/ypipe.hpp
@@ -62,9 +62,9 @@ template <typename T, int N> class ypipe_t : public ypipe_base_t<T>
     //  just to keep ICC and code checking tools from complaining.
     inline virtual ~ypipe_t () {}
 
-        //  Following function (write) deliberately copies uninitialised data
-        //  when used with zmq_msg. Initialising the VSM body for
-        //  non-VSM messages won't be good for performance.
+    //  Following function (write) deliberately copies uninitialised data
+    //  when used with zmq_msg. Initialising the VSM body for
+    //  non-VSM messages won't be good for performance.
 
 #ifdef ZMQ_HAVE_OPENVMS
 #pragma message save

--- a/src/ypipe_conflate.hpp
+++ b/src/ypipe_conflate.hpp
@@ -53,9 +53,9 @@ template <typename T> class ypipe_conflate_t : public ypipe_base_t<T>
     //  just to keep ICC and code checking tools from complaining.
     inline virtual ~ypipe_conflate_t () {}
 
-        //  Following function (write) deliberately copies uninitialised data
-        //  when used with zmq_msg. Initialising the VSM body for
-        //  non-VSM messages won't be good for performance.
+    //  Following function (write) deliberately copies uninitialised data
+    //  when used with zmq_msg. Initialising the VSM body for
+    //  non-VSM messages won't be good for performance.
 
 #ifdef ZMQ_HAVE_OPENVMS
 #pragma message save

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -275,12 +275,26 @@ int zmq_socket_monitor_versioned (void *s_,
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
         return -1;
-    return s->monitor (addr_, events_, event_version_);
+    return s->monitor (addr_, events_, event_version_, ZMQ_PAIR);
 }
 
 int zmq_socket_monitor (void *s_, const char *addr_, int events_)
 {
     return zmq_socket_monitor_versioned (s_, addr_, events_, 1);
+}
+
+int zmq_socket_monitor_versioned_typed (
+        void *s_,
+        const char *addr_,
+        uint64_t events_,
+        int event_version_,
+        int type_)
+{
+    zmq::socket_base_t *s = as_socket_base_t (s_);
+    if (!s)
+        return -1;
+
+    return s->monitor (addr_, events_, event_version_, type_);
 }
 
 int zmq_join (void *s_, const char *group_)

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -284,11 +284,7 @@ int zmq_socket_monitor (void *s_, const char *addr_, int events_)
 }
 
 int zmq_socket_monitor_versioned_typed (
-        void *s_,
-        const char *addr_,
-        uint64_t events_,
-        int event_version_,
-        int type_)
+  void *s_, const char *addr_, uint64_t events_, int event_version_, int type_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -716,7 +712,7 @@ const char *zmq_msg_gets (const zmq_msg_t *msg_, const char *property_)
     return NULL;
 }
 
-    // Polling.
+// Polling.
 
 #if defined ZMQ_HAVE_POLLER
 inline int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -133,11 +133,8 @@ int zmq_socket_monitor_versioned (void *s_,
                                   const char *addr_,
                                   uint64_t events_,
                                   int event_version_);
-int zmq_socket_monitor_versioned_typed (void *s_,
-                                        const char *addr_,
-                                        uint64_t events_,
-                                        int event_version_,
-                                        int type_);
+int zmq_socket_monitor_versioned_typed (
+  void *s_, const char *addr_, uint64_t events_, int event_version_, int type_);
 int zmq_socket_monitor_pipes_stats (void *s_);
 
 #endif // ZMQ_BUILD_DRAFT_API

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -133,6 +133,11 @@ int zmq_socket_monitor_versioned (void *s_,
                                   const char *addr_,
                                   uint64_t events_,
                                   int event_version_);
+int zmq_socket_monitor_versioned_typed (void *s_,
+                                        const char *addr_,
+                                        uint64_t events_,
+                                        int event_version_,
+                                        int type_);
 int zmq_socket_monitor_pipes_stats (void *s_);
 
 #endif // ZMQ_BUILD_DRAFT_API

--- a/tests/test_last_endpoint.cpp
+++ b/tests/test_last_endpoint.cpp
@@ -55,11 +55,25 @@ void test_last_endpoint ()
     test_context_socket_close (sb);
 }
 
+void test_missing_endpoint ()
+{
+    void *sb = test_context_socket (ZMQ_ROUTER);
+
+    char reported[255];
+    size_t size = 255;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, reported, &size));
+    TEST_ASSERT_EQUAL_STRING (reported, "");
+
+    test_context_socket_close (sb);
+}
+
 int main (void)
 {
     setup_test_environment ();
 
     UNITY_BEGIN ();
     RUN_TEST (test_last_endpoint);
+    RUN_TEST (test_missing_endpoint);
     return UNITY_END ();
 }

--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -126,8 +126,21 @@ void test_monitor_basic ()
 #if (defined ZMQ_CURRENT_EVENT_VERSION && ZMQ_CURRENT_EVENT_VERSION >= 2)      \
   || (defined ZMQ_CURRENT_EVENT_VERSION                                        \
       && ZMQ_CURRENT_EVENT_VERSION_DRAFT >= 2)
-void test_monitor_versioned_basic (bind_function_t bind_function_,
-                                   const char *expected_prefix_)
+void test_monitor_versioned_typed_invalid_socket_type ()
+{
+    void *client = test_context_socket (ZMQ_DEALER);
+
+    //  Socket monitoring only works with ZMQ_PAIR, ZMQ_PUB and ZMQ_PUSH.
+    TEST_ASSERT_FAILURE_ERRNO (
+      EINVAL, zmq_socket_monitor_versioned_typed (
+                client, "inproc://invalid-socket-type", 0, 2, ZMQ_CLIENT));
+
+    test_context_socket_close_zero_linger (client);
+}
+
+void test_monitor_versioned_typed_basic (bind_function_t bind_function_,
+                                         const char *expected_prefix_,
+                                         int type_)
 {
     char server_endpoint[MAX_SOCKET_STRING];
 
@@ -136,14 +149,36 @@ void test_monitor_versioned_basic (bind_function_t bind_function_,
     void *server = test_context_socket (ZMQ_DEALER);
 
     //  Monitor all events on client and server sockets
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_socket_monitor_versioned (
-      client, "inproc://monitor-client", ZMQ_EVENT_ALL_V2, 2));
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_socket_monitor_versioned (
-      server, "inproc://monitor-server", ZMQ_EVENT_ALL_V2, 2));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_socket_monitor_versioned_typed (
+      client, "inproc://monitor-client", ZMQ_EVENT_ALL_V2, 2, type_));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_socket_monitor_versioned_typed (
+      server, "inproc://monitor-server", ZMQ_EVENT_ALL_V2, 2, type_));
+
+    //  Choose the appropriate consumer socket type.
+    int mon_type;
+    switch (type_) {
+        case ZMQ_PAIR:
+            mon_type = ZMQ_PAIR;
+            break;
+        case ZMQ_PUSH:
+            mon_type = ZMQ_PULL;
+            break;
+        case ZMQ_PUB:
+            mon_type = ZMQ_SUB;
+            break;
+    }
 
     //  Create two sockets for collecting monitor events
-    void *client_mon = test_context_socket (ZMQ_PAIR);
-    void *server_mon = test_context_socket (ZMQ_PAIR);
+    void *client_mon = test_context_socket (mon_type);
+    void *server_mon = test_context_socket (mon_type);
+
+    //  Additionally subscribe to all events if a PUB socket is used.
+    if (type_ == ZMQ_PUB) {
+        TEST_ASSERT_SUCCESS_ERRNO (
+          zmq_setsockopt (client_mon, ZMQ_SUBSCRIBE, "", 0));
+        TEST_ASSERT_SUCCESS_ERRNO (
+          zmq_setsockopt (server_mon, ZMQ_SUBSCRIBE, "", 0));
+    }
 
     //  Connect these to the inproc endpoints so they'll get events
     TEST_ASSERT_SUCCESS_ERRNO (
@@ -225,25 +260,35 @@ void test_monitor_versioned_basic (bind_function_t bind_function_,
 void test_monitor_versioned_basic_tcp_ipv4 ()
 {
     static const char prefix[] = "tcp://127.0.0.1:";
-    test_monitor_versioned_basic (bind_loopback_ipv4, prefix);
+    // Calling 'monitor_versioned_typed' with ZMQ_PAIR is the equivalent of
+    // calling 'monitor_versioned'.
+    test_monitor_versioned_typed_basic (bind_loopback_ipv4, prefix, ZMQ_PAIR);
+    test_monitor_versioned_typed_basic (bind_loopback_ipv4, prefix, ZMQ_PUB);
+    test_monitor_versioned_typed_basic (bind_loopback_ipv4, prefix, ZMQ_PUSH);
 }
 
 void test_monitor_versioned_basic_tcp_ipv6 ()
 {
     static const char prefix[] = "tcp://[::1]:";
-    test_monitor_versioned_basic (bind_loopback_ipv6, prefix);
+    test_monitor_versioned_typed_basic (bind_loopback_ipv6, prefix, ZMQ_PAIR);
+    test_monitor_versioned_typed_basic (bind_loopback_ipv6, prefix, ZMQ_PUB);
+    test_monitor_versioned_typed_basic (bind_loopback_ipv6, prefix, ZMQ_PUSH);
 }
 
 void test_monitor_versioned_basic_ipc ()
 {
     static const char prefix[] = "ipc://";
-    test_monitor_versioned_basic (bind_loopback_ipc, prefix);
+    test_monitor_versioned_typed_basic (bind_loopback_ipc, prefix, ZMQ_PAIR);
+    test_monitor_versioned_typed_basic (bind_loopback_ipc, prefix, ZMQ_PUB);
+    test_monitor_versioned_typed_basic (bind_loopback_ipc, prefix, ZMQ_PUSH);
 }
 
 void test_monitor_versioned_basic_tipc ()
 {
     static const char prefix[] = "tipc://";
-    test_monitor_versioned_basic (bind_loopback_tipc, prefix);
+    test_monitor_versioned_typed_basic (bind_loopback_tipc, prefix, ZMQ_PAIR);
+    test_monitor_versioned_typed_basic (bind_loopback_tipc, prefix, ZMQ_PUB);
+    test_monitor_versioned_typed_basic (bind_loopback_tipc, prefix, ZMQ_PUSH);
 }
 
 #ifdef ZMQ_EVENT_PIPES_STATS
@@ -385,6 +430,7 @@ int main ()
 #if (defined ZMQ_CURRENT_EVENT_VERSION && ZMQ_CURRENT_EVENT_VERSION >= 2)      \
   || (defined ZMQ_CURRENT_EVENT_VERSION                                        \
       && ZMQ_CURRENT_EVENT_VERSION_DRAFT >= 2)
+    RUN_TEST (test_monitor_versioned_typed_invalid_socket_type);
     RUN_TEST (test_monitor_versioned_basic_tcp_ipv4);
     RUN_TEST (test_monitor_versioned_basic_tcp_ipv6);
     RUN_TEST (test_monitor_versioned_basic_ipc);


### PR DESCRIPTION
Mirror of zeromq libzmq#3506
Solution: Toggling the high bit of the 'event_version' field of the
'zmq_socket_monitor_versioned' method makes the monitoring socket
a `ZMQ_PUB` instead of a `ZMQ_PAIR`. Thus multiple subscribers can
retrieve events from the socket monitor concurrently.

This would fix #3505 by allowing concurrent calls to `zmq_connect` and `zmq_bind` that would block until authentication succeed or fails. Each call would need to create and connect a `SUB` socket to the monitor endpoint so that events can be independently retrieved. It is not ideal but it should work.

I realize that toggling the `event_version`'s high bit to modify behavior is a travesty but it probably won't ever be used anyway. This way, this is not a breaking change.

What do you think? Is this too messy?

