### PR TITLE
Mirror of zeromq libzmq#3514

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -425,15 +425,11 @@ void zmq::thread_ctx_t::start_thread (thread_t &thread_,
     thread_.setSchedulingParameters (_thread_priority, _thread_sched_policy,
                                      _thread_affinity_cpus);
 
-    char namebuf[16] = "";
-#ifdef ZMQ_HAVE_WINDOWS
-    LIBZMQ_UNUSED (name_);
-#else
+    char namebuf[128] = "";
     snprintf (namebuf, sizeof (namebuf), "%s%sZMQbg%s%s",
               _thread_name_prefix.empty () ? "" : _thread_name_prefix.c_str (),
               _thread_name_prefix.empty () ? "" : "/", name_ ? "/" : "",
               name_ ? name_ : "");
-#endif
     thread_.start (tfn_, arg_, namebuf);
 }
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -47,6 +47,7 @@ static unsigned int __stdcall thread_routine (void *arg_)
 #endif
 {
     zmq::thread_t *self = (zmq::thread_t *) arg_;
+    self->setThreadName (self->_name.c_str ());
     self->_tfn (self->_arg);
     return 0;
 }
@@ -54,9 +55,9 @@ static unsigned int __stdcall thread_routine (void *arg_)
 
 void zmq::thread_t::start (thread_fn *tfn_, void *arg_, const char *name_)
 {
-    LIBZMQ_UNUSED (name_);
     _tfn = tfn_;
     _arg = arg_;
+    _name = name_;
 #if defined _WIN32_WCE
     _descriptor =
       (HANDLE) CreateThread (NULL, 0, &::thread_routine, this, 0, NULL);
@@ -94,8 +95,30 @@ void zmq::thread_t::setSchedulingParameters (
 
 void zmq::thread_t::setThreadName (const char *name_)
 {
-    // not implemented
-    LIBZMQ_UNUSED (name_);
+    if (!name_)
+        return;
+
+    struct
+    {
+        DWORD _type = 0x1000;
+        LPCSTR _name = NULL;
+        DWORD _thread_id = 0;
+        DWORD flags = 0x0;
+    } thread_info;
+
+    thread_info._thread_id = GetCurrentThreadId();
+    thread_info._name = name_;
+
+    __try
+    {
+        DWORD MS_VC_EXCEPTION = 0x406D1388;
+        RaiseException (MS_VC_EXCEPTION, 0, sizeof (thread_info) / sizeof (ULONG_PTR),
+                        (const ULONG_PTR *) &thread_info);
+    }
+    __except (EXCEPTION_CONTINUE_EXECUTION)
+    {
+
+    }
 }
 
 #elif defined ZMQ_HAVE_VXWORKS

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -98,25 +98,21 @@ void zmq::thread_t::setThreadName (const char *name_)
     if (!name_)
         return;
 
-    struct
-    {
+    struct {
         DWORD _type = 0x1000;
         LPCSTR _name = NULL;
-        DWORD _thread_id = 0;
+        DWORD _thread_id = -1;
         DWORD flags = 0x0;
     } thread_info;
 
-    thread_info._thread_id = GetCurrentThreadId();
     thread_info._name = name_;
 
-    __try
-    {
+    __try {
         DWORD MS_VC_EXCEPTION = 0x406D1388;
         RaiseException (MS_VC_EXCEPTION, 0, sizeof (thread_info) / sizeof (ULONG_PTR),
                         (const ULONG_PTR *) &thread_info);
     }
-    __except (EXCEPTION_CONTINUE_EXECUTION)
-    {
+    __except (EXCEPTION_CONTINUE_EXECUTION) {
 
     }
 }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -93,7 +93,6 @@ void zmq::thread_t::setSchedulingParameters (
     LIBZMQ_UNUSED (affinity_cpus_);
 }
 
-
 void zmq::thread_t::setThreadName (const char *name_)
 {
     if (!name_)
@@ -106,7 +105,7 @@ void zmq::thread_t::setThreadName (const char *name_)
         DWORD _flags;
     } thread_info;
 
-	thread_info._type = 0x1000;
+    thread_info._type = 0x1000;
     thread_info._name = name_;
     thread_info._thread_id = -1;
     thread_info._flags = 0;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -93,24 +93,28 @@ void zmq::thread_t::setSchedulingParameters (
     LIBZMQ_UNUSED (affinity_cpus_);
 }
 
+
 void zmq::thread_t::setThreadName (const char *name_)
 {
     if (!name_)
         return;
 
     struct {
-        DWORD _type = 0x1000;
-        LPCSTR _name = NULL;
-        DWORD _thread_id = -1;
-        DWORD flags = 0x0;
+        DWORD _type;
+        LPCSTR _name;
+        DWORD _thread_id;
+        DWORD _flags;
     } thread_info;
 
+	thread_info._type = 0x1000;
     thread_info._name = name_;
+    thread_info._thread_id = -1;
+    thread_info._flags = 0;
 
     __try {
         DWORD MS_VC_EXCEPTION = 0x406D1388;
         RaiseException (MS_VC_EXCEPTION, 0, sizeof (thread_info) / sizeof (ULONG_PTR),
-                        (const ULONG_PTR *) &thread_info);
+                        (ULONG_PTR *) &thread_info);
     }
     __except (EXCEPTION_CONTINUE_EXECUTION) {
 


### PR DESCRIPTION
Mirror of zeromq libzmq#3514
Problem: thread_t::setThreadName() is not implemented on windows

Solution: implement setThreadName() by using the exception method (compatible with all win32 versions), and allow a larger thread name on all platforms (from 16 to 128 bytes)

More info here: https://docs.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2019
