### PR TITLE
Mirror of zeromq libzmq#3521

### DIFF
--- a/RELICENSE/jackpimbert.md
+++ b/RELICENSE/jackpimbert.md
@@ -1,0 +1,18 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Jack Pimbert that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "jackpimbert",
+with commit author "jackpimbert <jack.pimbert@gmail.com>", are
+copyright of Jack Pimbert.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Jack Pimbert
+2019/05/24
+
+

--- a/doc/zmq_pgm.txt
+++ b/doc/zmq_pgm.txt
@@ -130,6 +130,30 @@ Third datagram payload
 ....
 
 
+CONFIGURATION
+-------------
+
+The PGM is protocol is capable of multicasting data at high rates (500Mbps+)
+with large messages (1MB+), however it requires setting the relevent ZMQ socket
+options that are documented in linkzmq:zmq_setsockopt[3]:
+
+* The 'ZMQ_RATE' should be set sufficiently high, e.g. 1Gbps
+* The 'ZMQ_RCVBUF' should be increased on the subscriber, e.g. 4MB
+* The 'ZMQ_SNDBUF' should be increased on the publisher, e.g. 4MB
+
+It's important to note that the 'ZMQ_RCVBUF' and 'ZMQ_SNDBUF' options are
+limited by the underlying host OS tx/rx buffer size limit. On linux, these can
+be increased for the current session with the following commands:
+
+....
+# set tx/rx buffers to 4MB (default can also be read as the initial buffer size)
+sudo sysctl -w net.core.rmem_max=4194304
+sudo sysctl -w net.core.wmem_max=4194304
+sudo sysctl -w net.core.rmem_default=4194304
+sudo sysctl -w net.core.wmem_default=4194304
+....
+
+
 EXAMPLE
 -------
 .Connecting a socket


### PR DESCRIPTION
Mirror of zeromq libzmq#3521
Problem: PGM doc missing info on high data rates

Solution: Include a new section on configuring both ZMQ and the host
OS tx/rx buffers to facilitate sending large messages at a high data
rate with the PGM protocol.

---

Issue #2076 discusses problems that were encountered when attempting to multicast high data rates with the PGM protocol. There are some settings on both ZMQ and the host OS that must be changed in order to successfully multicast with higher rates. These setting changes have been added to the docs on PGM.

Please let me know if anything should be reformatted/moved to another place in the doc file.

