### PR TITLE
Mirror of zeromq libzmq#3515

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -425,11 +425,7 @@ void zmq::thread_ctx_t::start_thread (thread_t &thread_,
     thread_.setSchedulingParameters (_thread_priority, _thread_sched_policy,
                                      _thread_affinity_cpus);
 
-#ifdef ZMQ_HAVE_WINDOWS
-    char namebuf[32] = "";
-#else
     char namebuf[16] = "";
-#endif
     snprintf (namebuf, sizeof (namebuf), "%s%sZMQbg%s%s",
               _thread_name_prefix.empty () ? "" : _thread_name_prefix.c_str (),
               _thread_name_prefix.empty () ? "" : "/", name_ ? "/" : "",

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -425,15 +425,15 @@ void zmq::thread_ctx_t::start_thread (thread_t &thread_,
     thread_.setSchedulingParameters (_thread_priority, _thread_sched_policy,
                                      _thread_affinity_cpus);
 
-    char namebuf[16] = "";
 #ifdef ZMQ_HAVE_WINDOWS
-    LIBZMQ_UNUSED (name_);
+    char namebuf[32] = "";
 #else
+    char namebuf[16] = "";
+#endif
     snprintf (namebuf, sizeof (namebuf), "%s%sZMQbg%s%s",
               _thread_name_prefix.empty () ? "" : _thread_name_prefix.c_str (),
               _thread_name_prefix.empty () ? "" : "/", name_ ? "/" : "",
               name_ ? name_ : "");
-#endif
     thread_.start (tfn_, arg_, namebuf);
 }
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -52,11 +52,6 @@
 #include <vmci_sockets.h>
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf(buffer_, count_, format_, ...) \
-    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
-#endif
-
 #define ZMQ_CTX_TAG_VALUE_GOOD 0xabadcafe
 #define ZMQ_CTX_TAG_VALUE_BAD 0xdeadbeef
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -52,6 +52,11 @@
 #include <vmci_sockets.h>
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define snprintf(buffer_, count_, format_, ...) \
+    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
+#endif
+
 #define ZMQ_CTX_TAG_VALUE_GOOD 0xabadcafe
 #define ZMQ_CTX_TAG_VALUE_BAD 0xdeadbeef
 

--- a/src/io_thread.cpp
+++ b/src/io_thread.cpp
@@ -36,11 +36,6 @@
 #include "err.hpp"
 #include "ctx.hpp"
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf(buffer_, count_, format_, ...) \
-    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
-#endif
-
 zmq::io_thread_t::io_thread_t (ctx_t *ctx_, uint32_t tid_) :
     object_t (ctx_, tid_),
     _mailbox_handle (static_cast<poller_t::handle_t> (NULL))
@@ -61,7 +56,7 @@ zmq::io_thread_t::~io_thread_t ()
 
 void zmq::io_thread_t::start ()
 {
-    char name[16];
+    char name[16] = "";
     snprintf (name, sizeof (name), "IO/%u",
               get_tid () - zmq::ctx_t::reaper_tid - 1);
     //  Start the underlying I/O thread.

--- a/src/io_thread.cpp
+++ b/src/io_thread.cpp
@@ -36,6 +36,11 @@
 #include "err.hpp"
 #include "ctx.hpp"
 
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define snprintf(buffer_, count_, format_, ...) \
+    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
+#endif
+
 zmq::io_thread_t::io_thread_t (ctx_t *ctx_, uint32_t tid_) :
     object_t (ctx_, tid_),
     _mailbox_handle (static_cast<poller_t::handle_t> (NULL))
@@ -56,11 +61,9 @@ zmq::io_thread_t::~io_thread_t ()
 
 void zmq::io_thread_t::start ()
 {
-    char name[16] = "";
-#ifndef ZMQ_HAVE_WINDOWS
+    char name[16];
     snprintf (name, sizeof (name), "IO/%u",
               get_tid () - zmq::ctx_t::reaper_tid - 1);
-#endif
     //  Start the underlying I/O thread.
     _poller->start (name);
 }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -47,7 +47,8 @@ static unsigned int __stdcall thread_routine (void *arg_)
 #endif
 {
     zmq::thread_t *self = (zmq::thread_t *) arg_;
-    self->setThreadName (self->_name.c_str ());
+    if (!self->_name.empty ())
+        self->setThreadName (self->_name.c_str ());
     self->_tfn (self->_arg);
     return 0;
 }
@@ -57,7 +58,8 @@ void zmq::thread_t::start (thread_fn *tfn_, void *arg_, const char *name_)
 {
     _tfn = tfn_;
     _arg = arg_;
-    _name = name_;
+    if (name_)
+        _name = name_;
 #if defined _WIN32_WCE
     _descriptor =
       (HANDLE) CreateThread (NULL, 0, &::thread_routine, this, 0, NULL);
@@ -213,7 +215,8 @@ static void *thread_routine (void *arg_)
 #endif
     zmq::thread_t *self = (zmq::thread_t *) arg_;
     self->applySchedulingParameters ();
-    self->setThreadName (self->_name.c_str ());
+    if (!self->_name.empty ())
+        self->setThreadName (self->_name.c_str ());
     self->_tfn (self->_arg);
     return NULL;
 }
@@ -223,7 +226,8 @@ void zmq::thread_t::start (thread_fn *tfn_, void *arg_, const char *name_)
 {
     _tfn = tfn_;
     _arg = arg_;
-    _name = name_;
+    if (name_)
+        _name = name_;
     int rc = pthread_create (&_descriptor, NULL, thread_routine, this);
     posix_assert (rc);
     _started = true;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -47,6 +47,7 @@ static unsigned int __stdcall thread_routine (void *arg_)
 #endif
 {
     zmq::thread_t *self = (zmq::thread_t *) arg_;
+    self->setThreadName (self->_name.c_str ());
     self->_tfn (self->_arg);
     return 0;
 }
@@ -54,9 +55,9 @@ static unsigned int __stdcall thread_routine (void *arg_)
 
 void zmq::thread_t::start (thread_fn *tfn_, void *arg_, const char *name_)
 {
-    LIBZMQ_UNUSED (name_);
     _tfn = tfn_;
     _arg = arg_;
+    _name = name_;
 #if defined _WIN32_WCE
     _descriptor =
       (HANDLE) CreateThread (NULL, 0, &::thread_routine, this, 0, NULL);
@@ -92,10 +93,39 @@ void zmq::thread_t::setSchedulingParameters (
     LIBZMQ_UNUSED (affinity_cpus_);
 }
 
+namespace {
+#pragma pack(push, 8)
+    struct thread_info_t {
+        DWORD _type;
+        LPCSTR _name;
+        DWORD _thread_id;
+        DWORD _flags;
+    };
+#pragma pack(pop)
+}
+
 void zmq::thread_t::setThreadName (const char *name_)
 {
-    // not implemented
-    LIBZMQ_UNUSED (name_);
+    if (!name_)
+        return;
+
+    thread_info_t thread_info;
+    thread_info._type = 0x1000;
+    thread_info._name = name_;
+    thread_info._thread_id = -1;
+    thread_info._flags = 0;
+
+#pragma warning(push)
+#pragma warning(disable : 6320 6322)
+    __try {
+        DWORD MS_VC_EXCEPTION = 0x406D1388;
+        RaiseException (MS_VC_EXCEPTION, 0,
+                        sizeof (thread_info) / sizeof (ULONG_PTR),
+                        (ULONG_PTR *) &thread_info);
+    }
+    __except (EXCEPTION_CONTINUE_EXECUTION) {
+    }
+#pragma warning(pop)
 }
 
 #elif defined ZMQ_HAVE_VXWORKS

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -93,14 +93,16 @@ void zmq::thread_t::setSchedulingParameters (
     LIBZMQ_UNUSED (affinity_cpus_);
 }
 
-namespace {
+namespace
+{
 #pragma pack(push, 8)
-    struct thread_info_t {
-        DWORD _type;
-        LPCSTR _name;
-        DWORD _thread_id;
-        DWORD _flags;
-    };
+struct thread_info_t
+{
+    DWORD _type;
+    LPCSTR _name;
+    DWORD _thread_id;
+    DWORD _flags;
+};
 #pragma pack(pop)
 }
 

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -56,7 +56,6 @@ class thread_t
     inline thread_t () :
         _tfn (NULL),
         _arg (NULL),
-        _name (""),
         _started (false),
         _thread_priority (ZMQ_THREAD_PRIORITY_DFLT),
         _thread_sched_policy (ZMQ_THREAD_SCHED_POLICY_DFLT)

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -99,6 +99,6 @@ static inline int poll (struct pollfd *pfd, unsigned long nfds, int timeout)
 //  In MSVC prior to v14, snprintf is not available
 //  The closest implementation is the _snprintf_s function
 #if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf(buffer_, count_, format_, ...) \
+#define snprintf(buffer_, count_, format_, ...)                                \
     _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
 #endif

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -95,3 +95,10 @@ static inline int poll (struct pollfd *pfd, unsigned long nfds, int timeout)
 #define AI_NUMERICSERV 0x0400
 #endif
 #endif
+
+//  In MSVC prior to v14, snprintf is not available
+//  The closest implementation is the _snprintf_s function
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define snprintf(buffer_, count_, format_, ...) \
+    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
+#endif

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -46,11 +46,12 @@
 #include "../src/curve_client_tools.hpp"
 #include "../src/random.hpp"
 
-char error_message_buffer[256];
-
 #if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf _snprintf
+#define snprintf(buffer_, count_, format_, ...) \
+    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
 #endif
+
+char error_message_buffer[256];
 
 void *handler;
 void *zap_thread;

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -46,11 +46,6 @@
 #include "../src/curve_client_tools.hpp"
 #include "../src/random.hpp"
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf(buffer_, count_, format_, ...) \
-    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
-#endif
-
 char error_message_buffer[256];
 
 void *handler;

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -96,6 +96,13 @@ enum
 };
 #endif
 
+//  In MSVC prior to v14, snprintf is not available
+//  The closest implementation is the _snprintf_s function
+#if defined _MSC_VER && _MSC_VER < 1900
+#define snprintf(buffer_, count_, format_, ...) \
+    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
+#endif
+
 #define LIBZMQ_UNUSED(object) (void) object
 
 //  Bounce a message from client to server and back

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -99,7 +99,7 @@ enum
 //  In MSVC prior to v14, snprintf is not available
 //  The closest implementation is the _snprintf_s function
 #if defined _MSC_VER && _MSC_VER < 1900
-#define snprintf(buffer_, count_, format_, ...) \
+#define snprintf(buffer_, count_, format_, ...)                                \
     _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
 #endif
 

--- a/tests/testutil_unity.hpp
+++ b/tests/testutil_unity.hpp
@@ -35,8 +35,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <unity.h>
 
-#if defined(_MSC_VER) && _MSC_VER <= 1800
-#define snprintf _snprintf
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define snprintf(buffer_, count_, format_, ...) \
+    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
 #endif
 
 // Internal helper functions that are not intended to be directly called from

--- a/tests/testutil_unity.hpp
+++ b/tests/testutil_unity.hpp
@@ -35,11 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <unity.h>
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define snprintf(buffer_, count_, format_, ...) \
-    _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
-#endif
-
 // Internal helper functions that are not intended to be directly called from
 // tests. They must be declared in the header since they are used by macros.
 


### PR DESCRIPTION
Mirror of zeromq libzmq#3515
Problem: thread_t::setThreadName() is not implemented on windows

Solution: implement setThreadName() by using the exception method (compatible with all win32 versions)

More info here: https://docs.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2019
