### PR TITLE
Mirror of zeromq libzmq#3537

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -248,7 +248,7 @@ void zmq::thread_t::stop ()
 
 bool zmq::thread_t::is_current_thread () const
 {
-    return pthread_self () == _descriptor;
+    return bool( pthread_equal(pthread_self (), _descriptor) );
 }
 
 void zmq::thread_t::setSchedulingParameters (


### PR DESCRIPTION
Mirror of zeromq libzmq#3537
I am trying to port ZeroMQ to z/OS USS and I faced several problems. One of them is this function "is_current_thread" trying to compare two thread ids with operator "==". I've changed the code to use the official function "pthread_equal" to compare thread ids and now it's working fine.


# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL

This is a statement by Philippe Leite that grants permission to
relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
approved license chosen by the current ZeroMQ BDFL (Benevolent
Dictator for Life).

A portion of the commits made by the Github handle "philippeleite", with
commit author "Philippe Leite <philippe.leite<at>gmail.com>", are
copyright of Philippe Leite.  This document hereby grants the libzmq
project team to relicense libzmq, including all past, present and
future contributions of the author listed above.

Philippe Leite
2019/06/10
