### PR TITLE
Mirror of zeromq libzmq#3545

### DIFF
--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -922,6 +922,23 @@ Default value:: 0
 Applicable socket types:: ZMQ_ROUTER
 
 
+ZMQ_RADIO_NOTIFY: Receive 'join' and 'leave' notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Tells the RADIO socket to queue 'join' and 'leave' messages received from
+connected DISH sockets, so that the user can retrieve them using 'zmq_recv'.
+A notification is an empty 'zmq_msg' with an associated 'group'
+that can be accessed via 'zmq_msg_group'. The type of notification
+can be determined using 'zmq_msg_is_join' or 'zmq_msg_is_leave'.
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1
+Default value:: 0 (false)
+Applicable socket types:: ZMQ_RADIO
+
+
 RETURN VALUE
 ------------
 The _zmq_getsockopt()_ function shall return zero if successful. Otherwise it

--- a/doc/zmq_msg_is_join.txt
+++ b/doc/zmq_msg_is_join.txt
@@ -1,0 +1,35 @@
+
+zmq_msg_is_join(3)
+=====================
+
+
+NAME
+----
+zmq_msg_is_join - returns whether the msg is a 'join' notification.
+
+
+SYNOPSIS
+--------
+bool zmq_msg_is_join (zmq_msg_t '*message');*
+
+
+DESCRIPTION
+-----------
+The _zmq_msg_is_join()_ function returns whether the msg is a 'join'
+notification. A join notification can be received by a `ZMQ_RADIO` socket
+when ZMQ_RADIO_NOTIFY is set to one and a connected `ZMQ_DISH` socket joined
+a group.
+
+RETURN VALUE
+------------
+The _zmq_msg_is_join()_ function shall return 'true' if it is a 'join'
+notification.
+
+--------
+linkzmq:zmq_msg_is_join[3]
+
+
+AUTHORS
+-------
+This page was written by the 0MQ community. To make a change please
+read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.

--- a/doc/zmq_msg_is_leave.txt
+++ b/doc/zmq_msg_is_leave.txt
@@ -1,0 +1,35 @@
+
+zmq_msg_is_leave(3)
+=====================
+
+
+NAME
+----
+zmq_msg_is_leave - returns whether the msg is a 'leave' notification.
+
+
+SYNOPSIS
+--------
+bool zmq_msg_is_leave (zmq_msg_t '*message');*
+
+
+DESCRIPTION
+-----------
+The _zmq_msg_is_leave()_ function returns whether the msg is a 'leave'
+notification. A leave notification can be received by a `ZMQ_RADIO` socket
+when ZMQ_RADIO_NOTIFY is set to one and a connected `ZMQ_DISH` socket leaved
+a group.
+
+RETURN VALUE
+------------
+The _zmq_msg_is_leave()_ function shall return 'true' if it is a 'leave'
+notification.
+
+--------
+linkzmq:zmq_msg_is_leave[3]
+
+
+AUTHORS
+-------
+This page was written by the 0MQ community. To make a change please
+read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1362,6 +1362,23 @@ Default value:: 0
 Applicable socket types:: ZMQ_ROUTER
 
 
+ZMQ_RADIO_NOTIFY: Receive 'join' and 'leave' notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Tells the RADIO socket to queue 'join' and 'leave' messages received from
+connected DISH sockets, so that the user can retrieve them using 'zmq_recv'.
+A notification is an empty 'zmq_msg' with an associated 'group'
+that can be accessed via 'zmq_msg_group'. The type of notification
+can be determined using 'zmq_msg_is_join' or 'zmq_msg_is_leave'.
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1
+Default value:: 0 (false)
+Applicable socket types:: ZMQ_RADIO
+
+
 RETURN VALUE
 ------------
 The _zmq_setsockopt()_ function shall return zero if successful. Otherwise it

--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -183,7 +183,7 @@ option on sends. This limits them to single part data.
 .Summary of ZMQ_RADIO characteristics
 Compatible peer sockets:: 'ZMQ_DISH'
 Direction:: Unidirectional
-Send/receive pattern:: Send only
+Send/receive pattern:: Send only (unless 'ZMQ_RADIO_NOTIFY' is specified)
 Incoming routing strategy:: N/A
 Outgoing routing strategy:: Fan out
 Action in mute state:: Drop

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -658,6 +658,7 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_XPUB_MANUAL_LAST_VALUE 98
 #define ZMQ_SOCKS_USERNAME 99
 #define ZMQ_SOCKS_PASSWORD 100
+#define ZMQ_RADIO_NOTIFY 101
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_ZERO_COPY_RECV 10
@@ -671,6 +672,8 @@ ZMQ_EXPORT int zmq_msg_set_routing_id (zmq_msg_t *msg, uint32_t routing_id);
 ZMQ_EXPORT uint32_t zmq_msg_routing_id (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_set_group (zmq_msg_t *msg, const char *group);
 ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
+ZMQ_EXPORT bool zmq_msg_is_leave (zmq_msg_t *msg);
+ZMQ_EXPORT bool zmq_msg_is_join (zmq_msg_t *msg);
 
 /*  DRAFT Msg property names.                                                 */
 #define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -355,6 +355,10 @@ size_t zmq::msg_t::size () const
             return _u.zclmsg.content->size;
         case type_cmsg:
             return _u.cmsg.size;
+        case type_join:
+            return 0;
+        case type_leave:
+            return 0;
         default:
             zmq_assert (false);
             return 0;

--- a/src/radio.hpp
+++ b/src/radio.hpp
@@ -33,6 +33,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <queue>
 
 #include "socket_base.hpp"
 #include "session_base.hpp"
@@ -76,8 +77,12 @@ class radio_t : public socket_base_t
     //  Distributor of messages holding the list of outbound pipes.
     dist_t _dist;
 
+    std::queue<msg_t> _pending_notifs;
+
     //  Drop messages if HWM reached, otherwise return with EAGAIN
     bool _lossy;
+    //  Queue the join and leave messages so the client can `recv` them.
+    bool _notify;
 
     radio_t (const radio_t &);
     const radio_t &operator= (const radio_t &);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -684,6 +684,16 @@ const char *zmq_msg_group (zmq_msg_t *msg_)
     return (reinterpret_cast<zmq::msg_t *> (msg_))->group ();
 }
 
+bool zmq_msg_is_join (zmq_msg_t *msg_)
+{
+    return (reinterpret_cast<zmq::msg_t *> (msg_))->is_join ();
+}
+
+bool zmq_msg_is_leave (zmq_msg_t *msg_)
+{
+    return (reinterpret_cast<zmq::msg_t *> (msg_))->is_leave ();
+}
+
 //  Get message metadata string
 
 const char *zmq_msg_gets (const zmq_msg_t *msg_, const char *property_)

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -55,6 +55,7 @@
 #define ZMQ_XPUB_MANUAL_LAST_VALUE 98
 #define ZMQ_SOCKS_USERNAME 99
 #define ZMQ_SOCKS_PASSWORD 100
+#define ZMQ_RADIO_NOTIFY 101
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_ZERO_COPY_RECV 10
@@ -68,6 +69,9 @@ int zmq_msg_set_routing_id (zmq_msg_t *msg_, uint32_t routing_id_);
 uint32_t zmq_msg_routing_id (zmq_msg_t *msg_);
 int zmq_msg_set_group (zmq_msg_t *msg_, const char *group_);
 const char *zmq_msg_group (zmq_msg_t *msg_);
+bool zmq_msg_is_join (zmq_msg_t *msg_);
+bool zmq_msg_is_leave (zmq_msg_t *msg_);
+
 
 /*  DRAFT Msg property names.                                                 */
 #define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"


### PR DESCRIPTION
Mirror of zeromq libzmq#3545
Add `ZMQ_RADIO_NOTIFY` sockopt that queue join and leave messages
if set to 1. Add `zmq_msg_is_leave` and `zmq_msg_is_join` methods
to check whether a msg is a leave or join notification.

This would close #3474.
