### PR TITLE
Mirror of zeromq libzmq#3595

### DIFF
--- a/RELICENSE/aixxe.md
+++ b/RELICENSE/aixxe.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by aixxe (aixxe)
+that grants permission to relicense his copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "aixxe", with commit author
+"aixxe <me@aixxe.net>" are copyright of aixxe.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+aixxe
+2019/07/25

--- a/src/udp_address.cpp
+++ b/src/udp_address.cpp
@@ -104,11 +104,14 @@ int zmq::udp_address_t::resolve (const char *name_, bool bind_, bool ipv6_)
         if (src_name == "*") {
             _bind_interface = 0;
         } else {
+#if !defined ZMQ_HAVE_WINDOWS_TARGET_XP && !defined ZMQ_HAVE_WINDOWS_UWP       \
+  && !defined ZMQ_HAVE_VXWORKS
             _bind_interface = if_nametoindex (src_name.c_str ());
             if (_bind_interface == 0) {
                 //  Error, probably not an interface name.
                 _bind_interface = -1;
             }
+#endif
         }
 
         has_interface = true;


### PR DESCRIPTION
Mirror of zeromq libzmq#3595
Encountered the following error when compiling with `ZMQ_WIN32_WINNT` set to `0x0501`.

```
libzmq/src/udp_address.cpp: In member function 'int zmq::udp_address_t::resolve(const char*, bool, bool)':
libzmq/src/udp_address.cpp:107:31: error: 'if_nametoindex' was not declared in this scope
  107 |             _bind_interface = if_nametoindex (src_name.c_str ());
      |                               ^~~~~~~~~~~~~~
```

Wrapping a `ZMQ_HAVE_WINDOWS_TARGET_XP` check around the call seems to fix this.

I've used the same condition [as the one here](https://github.com/zeromq/libzmq/blob/b8b1b8def349f448f0861c6deeecae914213914c/src/ip_resolver.cpp#L707). Hope this all looks good.
