### PR TITLE
Mirror of zeromq libzmq#3591

### DIFF
--- a/doc/zmq_ctx_set.txt
+++ b/doc/zmq_ctx_set.txt
@@ -147,7 +147,7 @@ on the context. You can query the maximal allowed value with
 linkzmq:zmq_ctx_get[3] using the 'ZMQ_SOCKET_LIMIT' option.
 
 [horizontal]
-Default value:: 1024
+Default value:: 1023
 
 
 ZMQ_IPV6: Set IPv6 option


### PR DESCRIPTION
Mirror of zeromq libzmq#3591
Solution: update the doc with the correct default value

The doc incorrectly reports this constant to be `1024`.
https://github.com/zeromq/libzmq/blob/a84ffa12b2eb3569ced199660bac5ad128bff1f0/include/zmq.h#L228

